### PR TITLE
Add MkDocs configuration option to README

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -21,6 +21,10 @@
       - [Variables](#variables)
     - [Configuration](#configuration)
     - [Users](#users)
+    - [MkDocs](#mkdocs)
+      - [baseUrl](#baseurl)
+      - [rootDir](#rootdir)
+      - [Link Generation Mechanism](#link-generation-mechanism)
   - [Versioning](#versioning)
   - [Contributing](#contributing)
   - [License](#license)
@@ -401,6 +405,17 @@ illustrative purposes, but comments cannot be included in the actual json.
     // Specifies the maximum number of lines to display in the Issue body
     // default: 5
     "maxLines": 5
+  },
+  "mkdocs": {
+    // Configuration for generating links to static sites built with MkDocs
+    // Specify the base URL of the site
+    // default: not specified
+    // example: "https://your-site.github.io/your-repo"
+    "baseUrl": "",
+    // Specify the directory containing the documents to be built for the site pages
+    // default: not specified
+    // example: "docs"
+    "rootDir": ""
   }
 }
 ```
@@ -433,6 +448,41 @@ When notifying with a mentions, please enclose the alias name in the message wit
     webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
     message1: notification for <at>Admin</at> <at>Admin2</at>
 ```
+
+### MkDocs
+
+By configuring the MkDocs option, you can display changed files as links to static sites built with MkDocs. When this option is specified, the changed file
+paths displayed in `{CHANGED_FILES}` will be output as links to the deployed site.
+
+```json
+{
+  "mkdocs": {
+    "baseUrl": "https://your-site.github.io/your-repo",
+    "rootDir": "docs"
+  }
+}
+```
+
+#### baseUrl
+
+Specify the base URL of the site. Set the URL of the site deployed on GitHub Pages or other hosting services.
+
+#### rootDir
+
+Specify the directory containing the documents to be built for the site pages. Typically, specify the `docs` directory of your MkDocs project.
+
+#### Link Generation Mechanism
+
+When changed files are within the directory specified by `rootDir`, site URLs are generated based on those file paths.
+
+Example:
+
+- `baseUrl`: `https://your-site.github.io/your-repo`
+- `rootDir`: `docs`
+- Changed file: `docs/getting-started.md`
+- Generated link: `https://your-site.github.io/your-repo/getting-started/`
+
+By using this option, you can provide direct links to the relevant pages when notifying about document changes.
 
 ## Versioning
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@
       - [Variables](#variables)
     - [Configuration](#configuration)
     - [Users](#users)
+    - [MkDocs](#mkdocs)
+      - [baseUrl](#baseurl)
+      - [rootDir](#rootdir)
+      - [リンク生成の仕組み](#リンク生成の仕組み)
   - [Versioning](#versioning)
   - [Contributing](#contributing)
   - [License](#license)
@@ -398,6 +402,17 @@ configパラメータを指定することで、送信内容、条件のカス�
     // Issue本文の表示する最大行数を指定します
     // default: 5
     "maxLines": 5
+  },
+  "mkdocs": {
+    // MkDocsで構築された静的サイトへのリンクを生成するための設定
+    // サイトのベースURLを指定してください
+    // default: 指定なし
+    // example: "https://your-site.github.io/your-repo"
+    "baseUrl": "",
+    // サイトのページのビルド対象のドキュメントが含まれるディレクトリを指定してください
+    // default: 指定なし
+    // example: "docs"
+    "rootDir": ""
   }
 }
 ```
@@ -429,6 +444,40 @@ usersパラメータを指定することで、メンションを行うことが
     webhook-url: ${{ secrets.TEAMS_WEBHOOK_URL }}
     message1: notification for <at>Admin</at> <at>Admin2</at>
 ```
+
+### MkDocs
+
+MkDocsオプションを設定することで、変更ファイルをMkDocsで構築された静的サイトへのリンクとして表示できます。このオプションを指定すると、`{CHANGED_FILES}`で表示される変更ファイルのパスが、デプロイ先のサイトへのリンクとして出力されます。
+
+```json
+{
+  "mkdocs": {
+    "baseUrl": "https://your-site.github.io/your-repo",
+    "rootDir": "docs"
+  }
+}
+```
+
+#### baseUrl
+
+サイトのベースURLを指定してください。GitHub Pagesやその他のホスティングサービスでデプロイされたサイトのURLを設定します。
+
+#### rootDir
+
+サイトのページのビルド対象のドキュメントが含まれるディレクトリを指定してください。通常はMkDocsプロジェクトの`docs`ディレクトリを指定します。
+
+#### リンク生成の仕組み
+
+変更ファイルが`rootDir`で指定されたディレクトリ内にある場合、そのファイルパスを元にサイトのURLが生成されます。
+
+例：
+
+- `baseUrl`: `https://your-site.github.io/your-repo`
+- `rootDir`: `docs`
+- 変更ファイル: `docs/getting-started.md`
+- 生成されるリンク: `https://your-site.github.io/your-repo/getting-started/`
+
+このオプションを使用することで、ドキュメントの変更を通知する際に、該当するページに直接アクセスできるリンクを提供できます。
 
 ## Versioning
 


### PR DESCRIPTION
## Description

This pull request adds documentation for the MkDocs configuration option in both English and Japanese README files.

## Changes Made

- **Added MkDocs section** to both `README.md` (Japanese) and `README-en.md` (English)
- **Documented configuration options**:
  - `baseUrl`: Specify the base URL of the site deployed on GitHub Pages or other hosting services
  - `rootDir`: Specify the directory containing the documents to be built for the site pages
- **Added explanation** for the link generation mechanism with examples
- **Updated table of contents** to include the new MkDocs section

## What is MkDocs Option?

The MkDocs option allows users to display changed files as links to static sites built with MkDocs. When this option is specified, the changed file paths displayed in `{CHANGED_FILES}` will be output as links to the deployed site.

## Example Configuration

```json
{
  "mkdocs": {
    "baseUrl": "https://your-site.github.io/your-repo",
    "rootDir": "docs"
  }
}
```

## Link Generation Example

- `baseUrl`: `https://your-site.github.io/your-repo`
- `rootDir`: `docs`
- Changed file: `docs/getting-started.md`
- Generated link: `https://your-site.github.io/your-repo/getting-started/`

This enhancement provides direct links to the relevant pages when notifying about document changes, improving the user experience for documentation-focused projects.
